### PR TITLE
tests: add deserialization tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdmx-ser-tests"
+version = "0.1.0"
+dependencies = [
+ "sdmx",
+ "serde_json",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.216"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/sdmx-de-tests/Cargo.toml
+++ b/crates/sdmx-de-tests/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sdmx-ser-tests"
+description = "Testing JSON deserialization for sdmx crate"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+sdmx.path = "../sdmx"
+serde_json = "1.0.133"

--- a/crates/sdmx-de-tests/files/sample01.json
+++ b/crates/sdmx-de-tests/files/sample01.json
@@ -1,0 +1,31 @@
+{
+	"meta":{
+		"schema":"https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/data-message/tools/schemas/2.0.0/sdmx-json-data-schema.json",
+		"id":"IT1001",
+		"prepared":"2018-03-11T14:30:47",
+		"test":true,
+		"contentLanguages":[
+			"en"
+		],
+		"sender":{
+			"id":"NIS",
+			"name":"National Institute of Statistics of Cambodia",
+			"names":{
+				"en":"National Institute of Statistics of Cambodia"
+			}
+		},
+		"receiver":{
+			"id":"IMF",
+			"name":"International Monetary Fund",
+			"names":{
+				"en":"International Monetary Fund"
+			}
+		},
+		"links":[
+			{
+				"href":"http://ws-root/data/MA_545,MILLED_RICE,1.0/ASIKHM002+ASIKHM001../?dimensionAtObservation=AllDimensions&startPeriod=2013&endPeriod=2018",
+				"rel":"self"
+			}
+		]
+	}
+}

--- a/crates/sdmx-de-tests/files/sample01.json
+++ b/crates/sdmx-de-tests/files/sample01.json
@@ -1,30 +1,757 @@
 {
 	"meta":{
 		"schema":"https://raw.githubusercontent.com/sdmx-twg/sdmx-json/master/data-message/tools/schemas/2.0.0/sdmx-json-data-schema.json",
-		"id":"IT1001",
-		"prepared":"2018-03-11T14:30:47",
-		"test":true,
+		"id":"62b5f19d-f1c9-495d-8446-a3661ed24753",
+		"prepared":"2021-03-17T22:57:33Z",
+		"test":false,
 		"contentLanguages":[
 			"en"
 		],
 		"sender":{
-			"id":"NIS",
-			"name":"National Institute of Statistics of Cambodia",
+			"id":"ECB",
+			"name":"European Central Bank",
 			"names":{
-				"en":"National Institute of Statistics of Cambodia"
-			}
+				"en":"European Central Bank"
+			},
+			"contact":[
+				{
+					"name":"Statistics hotline",
+					"names":{
+						"en":"Statistics hotline"
+					},
+					"department":"Statistics Department",
+					"departments":{
+						"en":"Statistics Department"
+					},
+					"role":"helpdesk",
+					"roles":{
+						"en":"helpdesk"
+					},
+					"telephone":[
+						"+00-00-99999"
+					],
+					"fax":[
+						"+00-00-88888"
+					],
+					"uri":[
+						"http://www.xyz.org"
+					],
+					"email":[
+						"statistics@xyz.org"
+					]
+				}
+			]
 		},
 		"receiver":{
-			"id":"IMF",
-			"name":"International Monetary Fund",
+			"id":"SDMX",
+			"name":"SDMX",
 			"names":{
-				"en":"International Monetary Fund"
-			}
+				"en":"SDMX"
+			},
+			"contact":[
+				{
+					"name":"name",
+					"names":{
+						"en":"name"
+					},
+					"department":"department",
+					"departments":{
+						"en":"department"
+					},
+					"role":"role",
+					"roles":{
+						"en":"role"
+					},
+					"telephone":[
+						"telephone"
+					],
+					"fax":[
+						"fax"
+					],
+					"uri":[
+						"uri"
+					],
+					"email":[
+						"sdmx@xyz.org"
+					]
+				}
+			]
 		},
 		"links":[
 			{
-				"href":"http://ws-root/data/MA_545,MILLED_RICE,1.0/ASIKHM002+ASIKHM001../?dimensionAtObservation=AllDimensions&startPeriod=2013&endPeriod=2018",
-				"rel":"self"
+				"href":"http://www.myorg.org/ws/data/ECB_ICP1/M.PT.N.071100.4.INX",
+				"rel":"request",
+				"title":"Link to the url that returns this response",
+				"titles":{
+					"en":"Link to the url that returns this response"
+				},
+				"type":"application/json"
+			}
+		]
+	},
+	"errors":[
+		{
+			"code":123,
+			"title":"Invalid number of dimensions in parameter key",
+			"titles":{
+				"en":"Invalid number of dimensions in parameter key"
+			}
+		}
+	],
+	"data":{
+		"structures":[
+			{
+				"links":[
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/1.0",
+						"urn":"urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=ECB:ECB_EXR1(1.0)",
+						"rel":"datastructure",
+						"title":"resolvable uri to datastructure",
+						"titles":{
+							"en":"resolvable uri to datastructure"
+						}
+					},
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/dataflow/ECB/EXR",
+						"urn":"urn:sdmx:org.sdmx.infomodel.datastructure.Dataflow=ECB:EXR(1.0)",
+						"rel":"dataflow",
+						"title":"resolvable uri to dataflow",
+						"titles":{
+							"en":"resolvable uri to dataflow"
+						}
+					},
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/provisionagreement/ECB/PA_EXR",
+						"urn":"urn:sdmx:org.sdmx.infomodel.provisionagreement.ProvisionAgreement=ECB:PA_EXR(1.0)",
+						"rel":"provisionagreement",
+						"title":"resolvable uri to provision agreement",
+						"titles":{
+							"en":"resolvable uri to provision agreement"
+						}
+					}
+				],
+				"name":"dataflow name",
+				"names":{
+					"en":"dataflow name"
+				},
+				"description":"dataflow description",
+				"descriptions":{
+					"en":"dataflow description"
+				},
+				"dimensions":{
+					"dataSet":[
+						{
+							"id":"FREQ",
+							"name":"Frequency",
+							"names":{
+								"en":"Frequency"
+							},
+							"description":"Description for the dimension",
+							"descriptions":{
+								"en":"Description for the dimension"
+							},
+							"comment for keyPosition":"# 0-based position of dimension in key in user request url",
+							"keyPosition":0,
+							"comment for role":"# restricted list of dimension and attribute roles (time, frequency, geo, unit, scalefactor, referenceperiod, ...)",
+							"role":"frequency",
+							"values":[
+								{
+									"id":"D",
+									"name":"Daily",
+									"names":{
+										"en":"Daily"
+									}
+								}
+							]
+						},
+						{
+							"id":"CURRENCY_DENOM",
+							"name":"Currency denominator",
+							"names":{
+								"en":"Currency denominator"
+							},
+							"description":"Description for the dimension",
+							"descriptions":{
+								"en":"Description for the dimension"
+							},
+							"keyPosition":2,
+							"values":[
+								{
+									"id":"EUR",
+									"name":"Euro",
+									"names":{
+										"en":"Euro"
+									}
+								}
+							]
+						},
+						{
+							"id":"EXR_TYPE",
+							"name":"Exchange rate type",
+							"names":{
+								"en":"Exchange rate type"
+							},
+							"description":"Description for the dimension",
+							"descriptions":{
+								"en":"Description for the dimension"
+							},
+							"keyPosition":3,
+							"values":[
+								{
+									"id":"SP00",
+									"name":"Spot rate",
+									"names":{
+										"en":"Spot rate"
+									}
+								}
+							]
+						},
+						{
+							"id":"EXR_SUFFIX",
+							"name":"Series variation - EXR context",
+							"names":{
+								"en":"Series variation - EXR context"
+							},
+							"description":"Description for the dimension",
+							"descriptions":{
+								"en":"Description for the dimension"
+							},
+							"keyPosition":4,
+							"values":[
+								{
+									"id":"A",
+									"name":"Average or standardised measure for given frequency",
+									"names":{
+										"en":"Average or standardised measure for given frequency"
+									}
+								}
+							]
+						}
+					],
+					"series":[
+						{
+							"id":"CURRENCY",
+							"name":"Currency",
+							"names":{
+								"en":"Currency"
+							},
+							"description":"Description for the dimension",
+							"descriptions":{
+								"en":"Description for the dimension"
+							},
+							"keyPosition":1,
+							"role":"unit",
+							"values":[
+								{
+									"id":"NZD",
+									"name":"New Zealand dollar",
+									"names":{
+										"en":"New Zealand dollar"
+									}
+								},
+								{
+									"id":"RUB",
+									"name":"Russian rouble",
+									"names":{
+										"en":"Russian rouble"
+									}
+								}
+							]
+						}
+					],
+					"observation":[
+						{
+							"id":"TIME_PERIOD",
+							"name":"Time period or range",
+							"names":{
+								"en":"Time period or range"
+							},
+							"description":"Description for the dimension",
+							"descriptions":{
+								"en":"Description for the dimension"
+							},
+							"keyPosition":5,
+							"role":"time",
+							"values":[
+								{
+									"id":"2013-01-18",
+									"name":"2013-01-18",
+									"names":{
+										"en":"2013-01-18"
+									},
+									"start":"2013-01-18T00:00:00Z",
+									"end":"2013-01-18T23:59:59Z"
+								},
+								{
+									"id":"2013-01-21",
+									"name":"2013-01-21",
+									"names":{
+										"en":"2013-01-21"
+									},
+									"start":"2013-01-21T00:00:00Z",
+									"end":"2013-01-21T23:59:59Z"
+								}
+							]
+						}
+					]
+				},
+				"measures":{
+					"observation":[
+						{
+							"id":"OBS_VALUE",
+							"name":"Observation Value",
+							"names":{
+								"en":"Observation Value"
+							},
+							"description":"Description for the measure",
+							"descriptions":{
+								"en":"Description for the measure"
+							},
+							"relationship":{
+								"observation":{
+
+								}
+							},
+							"role":"PRIMARY",
+							"isMandatory":true,
+							"format":{
+								"dataType":"Double",
+								"minOccurs":1,
+								"maxOccurs":1,
+								"isMultiLingual":false
+							}
+						}
+					]
+				},
+				"attributes":{
+					"dataSet":[
+						{
+							"id":"TIME_FORMAT",
+							"name":"Time Format",
+							"names":{
+								"en":"Time Format"
+							},
+							"description":"Description for the attribute",
+							"descriptions":{
+								"en":"Description for the attribute"
+							},
+							"relationship":{
+								"dataflow":{
+
+								}
+							},
+							"role":"TIME_FORMAT",
+							"default":"P1D",
+							"values":[
+								{
+									"id":"P1D",
+									"name":"Daily",
+									"names":{
+										"en":"Daily"
+									}
+								}
+							]
+						},
+						{
+							"id":"DESCRIPTION",
+							"name":"Description",
+							"names":{
+								"en":"Description"
+							},
+							"description":"Description for the attribute",
+							"descriptions":{
+								"en":"Description for the attribute"
+							},
+							"relationship":{
+								"dataflow":{
+
+								}
+							},
+							"format":{
+								"dataType":"String",
+								"minOccurs":1,
+								"maxOccurs":2,
+								"minLength":5,
+								"maxLength":3000,
+								"isMultiLingual":false
+							}
+						}
+					],
+					"dimensionGroup":[
+						{
+							"id":"UNIT_MEAS",
+							"name":"Unit of Measure",
+							"names":{
+								"en":"Unit of Measure"
+							},
+							"description":"Description for the attribute",
+							"descriptions":{
+								"en":"Description for the attribute"
+							},
+							"relationship":{
+								"dimensions":[
+									"FREQ",
+									"EXR_TYPE",
+									"CURRENCY"
+								]
+							},
+							"role":"UNIT_MEAS",
+							"values":[
+								{
+									"id":"NC",
+									"name":"National Currency",
+									"names":{
+										"en":"National Currency"
+									}
+								}
+							]
+						}
+					],
+					"series":[
+						{
+							"id":"ID",
+							"name":"Attribute name",
+							"names":{
+								"en":"Attribute name"
+							},
+							"description":"Description for the attribute",
+							"descriptions":{
+								"en":"Description for the attribute"
+							},
+							"relationship":{
+								"dimensions":[
+									"FREQ",
+									"CURRENCY",
+									"CURRENCY_DENOM",
+									"EXR_TYPE",
+									"EXR_SUFFIX"
+								]
+							},
+							"role":null,
+							"default":"ID1",
+							"comment for values":"# inclusion of attachment level and its format to be decided, e.g. \"attachment\": [ true, true, true, true, true, true, false ],",
+							"values":[
+								{
+									"comment for id":"# id property is optional to allow for uncoded attributes",
+									"id":"ID1",
+									"name":"New Zealand dollar (NZD)",
+									"names":{
+										"en":"New Zealand dollar (NZD)"
+									}
+								},
+								{
+									"id":"ID2",
+									"name":"Russian rouble (RUB)",
+									"names":{
+										"en":"Russian rouble (RUB)"
+									}
+								}
+							]
+						}
+					],
+					"observation":[
+						{
+							"id":"EMBARGO_TIME",
+							"name":"Embargo time",
+							"names":{
+								"en":"Embargo time"
+							},
+							"roles":[
+								"EMBARGO_TIME"
+							],
+							"relationship":{
+								"observation":{}
+							},
+							"format":{
+								"dataType":"BasicTimePeriod",
+								"maxOccurs":1,
+								"isMultiLingual":false
+							}
+						},
+						{
+							"id":"OBS_STATUS",
+							"name":"Observation status",
+							"names":{
+								"en":"Observation status"
+							},
+							"description":"Description for the attribute",
+							"descriptions":{
+								"en":"Description for the attribute"
+							},
+							"relationship":{
+								"primaryMeasure":"OBS_VALUE"
+							},
+							"role":null,
+							"comment for default":"# optional",
+							"default":"A",
+							"comment for values":"# a null attribute can be used to shorten the message by using O index later in message",
+							"values":[
+								null,
+								{
+									"id":"A",
+									"name":"Normal value",
+									"names":{
+										"en":"Normal value"
+									},
+									"description":"Normal value",
+									"descriptions":{
+										"en":"Normal value"
+									}
+								}
+							]
+						}
+					]
+				},
+				"annotations":[
+					{
+						"title":"A title for the annotation.",
+						"type":"Used to distinguish between annotations.",
+						"value":"A non-localised value text of the annotation.",
+						"text":"A human-readable (best-language-match) text of the annotation.",
+						"texts":{
+							"en":"A human-readable localised text (English) of the annotation."
+						},
+						"id":"Non-standard identification of an annotation.",
+						"links":[
+							{
+								"href":"http://www.myorg.org/ws/uri/for/this/annotation",
+								"rel":"description"
+							}
+						]
+					}
+				],
+				"dataSets":[
+					0,
+					1,
+					2,
+					3,
+					4
+				]
+			}
+		],
+		"dataSets":[
+			{
+				"structure":0,
+				"links":[
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/1.0",
+						"urn":"urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=ECB:ECB_EXR1(1.0)",
+						"rel":"datastructure"
+					}
+				],
+				"action":"Information",
+				"reportingBegin":"2012-05-04",
+				"reportingEnd":"2012-06-01",
+				"validFrom":"2012-01-01T10:00:00Z",
+				"validTo":"2013-01-01T10:00:00Z",
+				"publicationYear":"2005",
+				"publicationPeriod":"2005-Q1",
+				"annotations":[
+					0
+				],
+				"attributes":[
+					0,
+					[
+						"Description value 1",
+						"Description value 2"
+					]
+				],
+				"dimensionGroupAttributes":{
+					"0::0::0:":[
+						0
+					],
+					"0::0::1:":[
+						0
+					]
+				},
+				"series":{
+					"0":{
+						"annotations":[
+
+						],
+						"attributes":[
+							0
+						],
+						"observations":{
+							"0":[
+								1.5931,
+								"2013-03-18T11:00:00",
+								0
+							],
+							"1":[
+								1.5925,
+								"2013-03-21T11:00:00",
+								0
+							]
+						}
+					},
+					"1":{
+						"annotations":[
+							0
+						],
+						"attributes":[
+							1
+						],
+						"observations":{
+							"0":[
+								40.3426,
+								"2013-03-18T11:00:00",
+								0
+							],
+							"1":[
+								40.3,
+								"2013-03-21T11:00:00",
+								0
+							]
+						}
+					}
+				}
+			},
+			{
+				"structure":0,
+				"links":[
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/1.0",
+						"urn":"urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=ECB:ECB_EXR1(1.0)",
+						"rel":"datastructure"
+					}
+				],
+				"action":"Information",
+				"attributes":[
+					0,
+					[
+						"Description value 1",
+						"Description value 2"
+					]
+				],
+				"dimensionGroupAttributes":{
+					"0::0::0:":[
+						0
+					],
+					"0::0::1:":[
+						0
+					]
+				},
+				"comment for observations":"# 2nd alternative instead of series if no series level (dimensionAtObservation == allDimensions)",
+				"observations":{
+					"0:0":[
+						1.5931,
+						"2013-03-18T11:00:00",
+						0
+					],
+					"0:1":[
+						1.5925,
+						"2013-03-21T11:00:00",
+						0
+					],
+					"1:0":[
+						40.3426,
+						"2013-03-18T11:00:00",
+						0,
+						0
+					],
+					"1:1":[
+						40.3,
+						"2013-03-21T11:00:00",
+						0,
+						0
+					]
+				}
+			},
+			{
+				"structure":0,
+				"links":[
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/1.0",
+						"urn":"urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=ECB:ECB_EXR1(1.0)",
+						"rel":"datastructure"
+					}
+				],
+				"action":"Information",
+				"comment for dataSet(s)":"# In case the client is using the detail parameter and the server supports it. # Detail parameter: serieskeysonly. No observation values, attributes or annotations.",
+				"observations":{
+					"0:0":[
+					],
+					"0:1":[
+					],
+					"1:0":[
+					],
+					"1:1":[
+					]
+				}
+			},
+			{
+				"structure":0,
+				"links":[
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/1.0",
+						"urn":"urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=ECB:ECB_EXR1(1.0)",
+						"rel":"datastructure"
+					}
+				],
+				"action":"Information",
+				"comment for dataSet(s)":"# Detail parameter: dataonly. No attributes or annotations.",
+				"observations":{
+					"0:0":[
+						1.5931
+					],
+					"0:1":[
+						1.5925
+					],
+					"1:0":[
+						40.3426
+					],
+					"1:1":[
+						40.3
+					]
+				}
+			},
+			{
+				"structure":0,
+				"links":[
+					{
+						"href":"https://sdw-wsrest.ecb.europa.eu/service/datastructure/ECB/ECB_EXR1/1.0",
+						"urn":"urn:sdmx:org.sdmx.infomodel.datastructure.DataStructure=ECB:ECB_EXR1(1.0)",
+						"rel":"datastructure"
+					}
+				],
+				"action":"Information",
+				"attributes":[
+					0,
+					[
+						"Description value 1",
+						"Description value 2"
+					]
+				],
+				"dimensionGroupAttributes":{
+					"0::0::0:":[
+						0
+					],
+					"0::0::1:":[
+						0
+					]
+				},
+				"comment for dataSet(s)":"# Detail parameter: nodata. No observation values, just attributes and annotations.",
+				"observations":{
+					"0:0":[
+						"2013-03-18T11:00:00",
+						0
+					],
+					"0:1":[
+						"2013-03-21T11:00:00",
+						0
+					],
+					"1:0":[
+						"2013-03-18T11:00:00",
+						0,
+						0
+					],
+					"1:1":[
+						"2013-03-21T11:00:00",
+						0,
+						0
+					]
+				}
 			}
 		]
 	}

--- a/crates/sdmx-de-tests/src/lib.rs
+++ b/crates/sdmx-de-tests/src/lib.rs
@@ -1,0 +1,46 @@
+use sdmx::data::DataMessage;
+use std::error::Error;
+use std::fmt::Display;
+use std::fs::read_to_string;
+use std::str::FromStr;
+
+#[derive(Debug)]
+pub enum ReadJsonError {
+	IO(std::io::Error),
+	Serde(serde_json::Error),
+}
+
+impl Error for ReadJsonError {}
+impl Display for ReadJsonError {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		match self {
+			ReadJsonError::IO(e) => write!(f, "IO error while reading: {}", e),
+			ReadJsonError::Serde(e) => write!(f, "Serde error while parsing: {}", e),
+		}
+	}
+}
+
+pub fn read_json(path: &str) -> Result<DataMessage, ReadJsonError> {
+	match read_to_string(path) {
+		Ok(s) => DataMessage::from_str(&s).map_err(ReadJsonError::Serde),
+		Err(e) => Err(ReadJsonError::IO(e)),
+	}
+}
+
+#[macro_export]
+macro_rules! fixture {
+	($fname:expr) => {
+		concat!(env!("CARGO_MANIFEST_DIR"), "/files/", $fname) // assumes Linux ('/')!
+	};
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_sample01() {
+		let file = read_json(fixture!("sample01.json"));
+		print!("{:?}", file);
+	}
+}

--- a/crates/sdmx-de-tests/src/lib.rs
+++ b/crates/sdmx-de-tests/src/lib.rs
@@ -39,6 +39,7 @@ mod tests {
 	use super::*;
 
 	#[test]
+	#[cfg_attr(miri, ignore)]
 	fn test_sample01() {
 		let file = read_json(fixture!("sample01.json"));
 		print!("{:?}", file);

--- a/crates/sdmx/src/common.rs
+++ b/crates/sdmx/src/common.rs
@@ -3,7 +3,19 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 pub type LocalizedText = HashMap<String, String>;
-pub type Links = Vec<String>;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+pub struct Link {
+	pub href: String,
+	pub rel: String,
+	pub url: Option<String>,
+	pub uri: Option<String>,
+	pub title: Option<String>,
+	pub titles: Option<LocalizedText>,
+	#[serde(rename = "type")]
+	pub type_: Option<String>,
+	pub hreflang: Option<String>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Action {
@@ -30,7 +42,7 @@ pub struct Annotation {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub texts: Option<LocalizedText>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
@@ -116,7 +128,7 @@ pub struct Error {
 	pub titles: LocalizedText,
 	pub detail: String,
 	pub details: LocalizedText,
-	pub links: Links,
+	pub links: Vec<Link>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
@@ -126,9 +138,9 @@ pub struct Error {
 #[serde(rename_all = "camelCase")]
 pub struct Party {
 	pub id: String,
-	pub name: String,
+	pub name: Option<String>,
 	pub names: LocalizedText,
-	pub contacts: Vec<Contact>,
+	pub contacts: Option<Vec<Contact>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
@@ -136,6 +148,29 @@ pub struct Party {
 
 pub type Sender = Party;
 pub type Receiver = Party;
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct MetaSingleReceiver {
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub schema: Option<String>,
+	pub id: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub test: Option<bool>,
+	pub prepared: String,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub content_languages: Option<Vec<String>>,
+	pub name: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub names: Option<LocalizedText>,
+	pub sender: Sender,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub receiver: Option<Receiver>,
+	pub links: Vec<Link>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[serde(flatten)]
+	pub other: Option<HashMap<String, Value>>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -153,8 +188,8 @@ pub struct MetaManyReceivers {
 	pub names: Option<LocalizedText>,
 	pub sender: Sender,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub receiver: Option<Vec<Receiver>>,
-	pub links: Links,
+	pub receivers: Option<Vec<Receiver>>,
+	pub links: Vec<Link>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,

--- a/crates/sdmx/src/common.rs
+++ b/crates/sdmx/src/common.rs
@@ -97,6 +97,10 @@ pub enum DataType {
 	Count,
 	InclusiveValueRange,
 	ExclusiveValueRange,
+	Incremental,
+	ObservationalTimePeriod,
+	StandardTimePeriod,
+	BasicTimePeriod,
 	GregorianTimePeriod,
 	GregorianYear,
 	GregorianYearMonth,
@@ -201,16 +205,18 @@ pub enum NumberOrString {
 	String(String),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
 pub enum SdmxValue {
 	String(String),
-	Number(isize),
+	Integer(isize),
+	Number(f64),
 	Boolean(bool),
 	LocalizedText(LocalizedText),
 	Array(Box<Vec<SdmxValue>>),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SdmxObject(pub HashMap<String, SdmxValue>);
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]

--- a/crates/sdmx/src/data.rs
+++ b/crates/sdmx/src/data.rs
@@ -1,6 +1,5 @@
 use crate::{
-	Action, Annotation, DataType, Error, Links, LocalizedText, MetaManyReceivers, NumberOrString,
-	SdmxObject, SdmxValue,
+	Action, Annotation, DataType, Error, Link, LocalizedText, MetaSingleReceiver, NumberOrString, SdmxObject, SdmxValue
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -10,7 +9,7 @@ use std::str::FromStr;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub struct DataMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub meta: Option<MetaManyReceivers>,
+	pub meta: Option<MetaSingleReceiver>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub data: Option<Data>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -57,7 +56,7 @@ pub struct Data {
 #[serde(rename_all = "camelCase")]
 pub struct Structure {
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub dimensions: Dimensions,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub measures: Option<Measures>,
@@ -113,7 +112,7 @@ pub struct Component {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub default_value: Option<NumberOrString>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<String>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -198,7 +197,7 @@ pub struct ComponentValue {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub order: Option<isize>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -226,7 +225,7 @@ pub struct DataSet {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub publication_period: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/sdmx/src/data.rs
+++ b/crates/sdmx/src/data.rs
@@ -1,5 +1,6 @@
 use crate::{
-	Action, Annotation, DataType, Error, Link, LocalizedText, MetaSingleReceiver, NumberOrString, SdmxObject, SdmxValue
+	Action, Annotation, DataType, Error, Link, LocalizedText, MetaSingleReceiver, NumberOrString,
+	SdmxObject, SdmxValue,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/sdmx/src/data.rs
+++ b/crates/sdmx/src/data.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct DataMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub meta: Option<MetaSingleReceiver>,
@@ -40,19 +40,19 @@ impl TryFrom<Value> for DataMessage {
 	}
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Data {
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub structures: Option<Structure>,
+	pub structures: Option<Vec<Structure>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub data_sets: Option<DataSet>,
+	pub data_sets: Option<Vec<DataSet>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Structure {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -64,7 +64,7 @@ pub struct Structure {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub datasets: Option<DataSet>,
+	pub dataset: Option<DataSet>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
@@ -74,7 +74,7 @@ pub type Dimensions = DimsMeasuresAttributes;
 pub type Measures = DimsMeasuresAttributes;
 pub type Attributes = DimsMeasuresAttributes;
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DimsMeasuresAttributes {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -90,7 +90,7 @@ pub struct DimsMeasuresAttributes {
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Component {
 	pub id: String,
@@ -98,15 +98,15 @@ pub struct Component {
 	pub name: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub names: Option<LocalizedText>,
-	pub description: String,
+	pub description: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub descriptions: Option<LocalizedText>,
-	pub key_position: usize,
+	pub key_position: Option<usize>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub roles: Option<Vec<String>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub is_mandatory: Option<bool>,
-	pub relationship: AttributeRelationship,
+	pub relationship: Option<AttributeRelationship>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub format: Option<Format>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -116,7 +116,7 @@ pub struct Component {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<String>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub values: Option<Vec<ComponentValue>>,
+	pub values: Option<Vec<Option<ComponentValue>>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
@@ -176,7 +176,7 @@ pub struct Format {
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct ComponentValue {
 	pub id: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -185,7 +185,7 @@ pub struct ComponentValue {
 	pub names: Option<LocalizedText>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub values: Option<Vec<SdmxValue>>,
-	pub description: String,
+	pub description: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub descriptions: Option<LocalizedText>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -205,7 +205,7 @@ pub struct ComponentValue {
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DataSet {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -227,13 +227,13 @@ pub struct DataSet {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub annotations: Option<Vec<Annotation>>,
+	pub annotations: Option<Vec<usize>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub attributes: Option<Vec<Attributes>>,
+	pub attributes: Option<Vec<SdmxValue>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub dimension_group_attributes: Option<SdmxObject>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub series: Option<Vec<Series>>,
+	pub series: Option<Series>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub observations: Option<SdmxObject>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -241,7 +241,7 @@ pub struct DataSet {
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Series {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,

--- a/crates/sdmx/src/metadata.rs
+++ b/crates/sdmx/src/metadata.rs
@@ -1,5 +1,5 @@
 use crate::{
-	Action, Annotation, DataType, Link, LocalizedText, MetaManyReceivers, NumberOrString, SdmxValue
+	Action, Annotation, DataType, Link, LocalizedText, MetaManyReceivers, NumberOrString, SdmxValue,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;

--- a/crates/sdmx/src/metadata.rs
+++ b/crates/sdmx/src/metadata.rs
@@ -1,6 +1,5 @@
 use crate::{
-	Action, Annotation, DataType, Links, LocalizedText, MetaManyReceivers, NumberOrString,
-	SdmxValue,
+	Action, Annotation, DataType, Link, LocalizedText, MetaManyReceivers, NumberOrString, SdmxValue
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -79,7 +78,7 @@ pub struct MetadataSet {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub name: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub names: Option<LocalizedText>,
@@ -151,7 +150,7 @@ pub struct StatusMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub details: Option<LocalizedText>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,

--- a/crates/sdmx/src/metadata.rs
+++ b/crates/sdmx/src/metadata.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
 pub struct MetadataMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub meta: Option<MetaManyReceivers>,
@@ -40,7 +40,7 @@ impl TryFrom<Value> for MetadataMessage {
 	}
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Data {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -50,7 +50,7 @@ pub struct Data {
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataSet {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -93,7 +93,7 @@ pub struct MetadataSet {
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 pub struct Attributes {
 	pub id: String,
 	#[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/sdmx/src/structure/all.rs
+++ b/crates/sdmx/src/structure/all.rs
@@ -1,5 +1,5 @@
 use crate::structure::{CommonArtefactType, DataConstraint, MetadataConstraint};
-use crate::{Annotation, DataType, Error, Links, LocalizedText, Receiver, Sender, SentinelValue};
+use crate::{Annotation, DataType, Error, Link, LocalizedText, MetaSingleReceiver, SentinelValue};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -8,7 +8,7 @@ use std::str::FromStr;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct StructureMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub meta: Option<Meta>,
+	pub meta: Option<MetaSingleReceiver>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub data: Option<Data>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -37,30 +37,6 @@ impl TryFrom<Value> for StructureMessage {
 	fn try_from(value: Value) -> Result<Self, Self::Error> {
 		serde_json::from_value(value)
 	}
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct Meta {
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub schema: Option<String>,
-	pub id: String,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub test: Option<bool>,
-	pub prepared: String,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub content_languages: Option<Vec<String>>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub name: Option<String>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub names: Option<LocalizedText>,
-	pub sender: Sender,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub receiver: Option<Receiver>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	#[serde(flatten)]
-	pub other: Option<HashMap<String, Value>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
@@ -196,7 +172,7 @@ pub struct Item {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
@@ -238,7 +214,7 @@ pub struct AttributeList {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attributes: Option<Vec<Attribute>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -254,7 +230,7 @@ pub struct Attribute {
 	pub id: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub usage: Usage,
 	pub attribute_relationship: AttributeRelationship,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -392,7 +368,7 @@ pub struct MetadataAttributeUsage {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub metadata_attribute_reference: String,
 	pub attribute_relationship: AttributeRelationship,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -408,7 +384,7 @@ pub struct DimensionList {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<String>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub dimensions: Option<Vec<Dimension>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -426,7 +402,7 @@ pub struct Dimension {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub position: usize,
 	pub concept_identity: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -446,7 +422,7 @@ pub struct TimeDimension {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub concept_identity: String,
 	pub local_representation: LocalRepresentation,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -496,7 +472,7 @@ pub struct Group {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub group_dimensions: Option<Vec<String>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -510,7 +486,7 @@ pub struct MeasureList {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub measures: Option<Vec<Measure>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -525,7 +501,7 @@ pub struct Measure {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub concept_identity: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub concept_roles: Option<Vec<String>>,
@@ -565,7 +541,7 @@ pub struct MetadataAttributeList {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub metadata_attributes: Option<Vec<MetadataAttribute>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -580,7 +556,7 @@ pub struct MetadataAttribute {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub concept_identity: String,
 	// TODO: this local repr can't have min_occurs/max_occurs
 	pub local_representation: LocalRepresentation,

--- a/crates/sdmx/src/structure/common.rs
+++ b/crates/sdmx/src/structure/common.rs
@@ -1,4 +1,4 @@
-use crate::{Annotation, Links, LocalizedText};
+use crate::{Annotation, Link, LocalizedText};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -24,7 +24,7 @@ pub struct CommonArtefactType {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,

--- a/crates/sdmx/src/structure/constraints.rs
+++ b/crates/sdmx/src/structure/constraints.rs
@@ -1,5 +1,5 @@
 use crate::structure::CommonArtefactType;
-use crate::{Annotation, Links};
+use crate::{Annotation, Link};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
@@ -104,7 +104,7 @@ pub struct CubeRegion {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub include: Option<bool>,
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -228,7 +228,7 @@ pub struct DataKey {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	pub include: bool,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub valid_from: Option<String>,
@@ -297,7 +297,7 @@ pub struct MetadataTargetRegion {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Links>,
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub include: Option<bool>,
 	#[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Contains some fixes from handwritten implementation:

- common: Fixed implementation of Link symbol (an object, not a string)
  - Removed type alias and inline the definition where referenced
- common: Replace Meta symbol implementation with MetaSingleReceiver and MetaManyReceivers
- common: DataType enum how has 4 new variants: `Incremental`, `ObservationalTimePeriod`, `StandardTimePeriod`, and `BasicTimePeriod`
- common: SdmxValue enum is now untagged
- common: SdmxValue enum now has `Number` variant
  - remove `Eq` derive implementation for some structs since f64 cannot implement Eq
- data: Meta field `name` is now optional
- data: Data field `structures` is now `Option<Vec<Structure>>`
- data: Data field `data_sets` is now `Option<Vec<DataSet>>`
- data: Structure field `datasets` is now `dataset`
- data: Component field `description` is now optional
- data: Component field `relationship` is now optional
- data: Component field `values` is now `Option<Vec<Option<ComponentValue>>>`
- data: ComponentValue field `description` is now optional
- data: DataSet field `annotations` is now `Option<Vec<usize>>`
- data: DataSet field `attributes` is now `Option<Vec<SdmxValue>>`
- data: DataSet field `series` is now `Option<Vec<Series>>`