### PR TITLE
release: first release, v0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # sdmx
-
 [![License][license-badge]][license-url]
 [![CI][ci-badge]][ci-url]
 [![Security audit][security-badge]][security-url]
@@ -11,14 +10,13 @@
 [security-badge]: https://img.shields.io/github/actions/workflow/status/neoncitylights/sdmx/.github/workflows/main.yml?style=flat-square
 [security-url]: https://github.com/neoncitylights/sdmx/actions/workflows/security-audit.yml
 
-This monorepo provides Rust-related crates to SDMX (Statistical Data and Metadata eXchange). At the moment, this currently implements SDMX-JSON, and may provide a crate for SDMX-ML in the future.
+This monorepo provides Rust-related crates to SDMX (Statistical Data and Metadata eXchange). At the moment, this currently implements [SDMX-JSON](https://github.com/sdmx-twg/sdmx-json), and may provide a crate for [SDMX-ML](https://github.com/sdmx-twg/sdmx-ml) in the future.
 
 | Crate     | crates.io | docs.rs |
 | --------- | --------- | ------- |
-| [`sdmx_json`](./crates/sdmx_json) | [crates.io](https://crates.io/crates/sdmx_json) | [crates.io](https://docs.rs/sdmx_json) |
+| [`sdmx_json`](./crates/sdmx_json) | [crates.io](https://crates.io/crates/sdmx_json) | [docs.rs](https://docs.rs/sdmx_json) |
 
 ## License
-
 Licensed under either of
 
 - Apache License, Version 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
@@ -27,5 +25,4 @@ Licensed under either of
 at your option.
 
 ### Contribution
-
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-# sdmx_json
+# sdmx
 
 [![License][license-badge]][license-url]
 [![CI][ci-badge]][ci-url]
 [![Security audit][security-badge]][security-url]
-[![Codecov][codecov-badge]][codecov-url]
 
 [license-badge]: https://img.shields.io/badge/License-MIT%20%26%20Apache%202.0-blue?style=flat-square
 [license-url]: #license
@@ -11,16 +10,12 @@
 [ci-url]: https://github.com/neoncitylights/sdmx/actions/workflows/main.yml
 [security-badge]: https://img.shields.io/github/actions/workflow/status/neoncitylights/sdmx/.github/workflows/main.yml?style=flat-square
 [security-url]: https://github.com/neoncitylights/sdmx/actions/workflows/security-audit.yml
-[codecov-badge]: https://img.shields.io/codecov/c/github/neoncitylights/rust?style=flat-square&logo=codecov&logoColor=%23fff
-[codecov-url]: https://codecov.io/gh/neoncitylights/sdmx
 
-A Rust implementation of SDMX-JSON (Statistical Data and Metadata eXchange) using Serde.
+This monorepo provides Rust-related crates to SDMX (Statistical Data and Metadata eXchange). At the moment, this currently implements SDMX-JSON, and may provide a crate for SDMX-ML in the future.
 
-## Install
-
-```shell
-cargo add sdmx_json
-```
+| Crate     | crates.io | docs.rs |
+| --------- | --------- | ------- |
+| [`sdmx_json`](./crates/sdmx_json) | [crates.io](https://crates.io/crates/sdmx_json) | [crates.io](https://docs.rs/sdmx_json) |
 
 ## License
 

--- a/crates/sdmx_json/CHANGELOG.md
+++ b/crates/sdmx_json/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.1.0 (YYYY-MM-DD)
+## v0.1.0 (2024-12-15)
 
-- Initial release of the sdmx library
+- Initial release of the sdmx_json library

--- a/crates/sdmx_json/Cargo.toml
+++ b/crates/sdmx_json/Cargo.toml
@@ -10,8 +10,11 @@ repository = "https://github.com/neoncitylights/sdmx"
 edition = "2021"
 rust-version = "1.76.0"
 
-keywords = []
-categories = []
+keywords = ["sdmx"]
+categories = [
+	"encoding",
+	"parser"
+]
 
 include = ["src", "LICENSE*"]
 

--- a/crates/sdmx_json/README.md
+++ b/crates/sdmx_json/README.md
@@ -1,36 +1,31 @@
 # sdmx_json
+[![License][license]][license-url]
+[![CI][ci]][ci-url]
+[![Codecov][codecov]][codecov-url]
+[![Documentation][docs]][docs-url]
 
-[![License][license-badge]][license-url]
-[![CI][ci-badge]][ci-url]
-[![Security audit][security-badge]][security-url]
-[![Codecov][codecov-badge]][codecov-url]
-
-[license-badge]: https://img.shields.io/badge/License-MIT%20%26%20Apache%202.0-blue?style=flat-square
+[license]: https://img.shields.io/badge/License-MIT%20%26%20Apache%202.0-blue?style=flat-square
 [license-url]: #license
-[ci-badge]: https://img.shields.io/github/deployments/neoncitylights/sdmx/github-pages?label=deploy&style=flat-square
+[ci]: https://img.shields.io/github/deployments/neoncitylights/sdmx/github-pages?label=deploy&style=flat-square
 [ci-url]: https://github.com/neoncitylights/sdmx/actions/workflows/main.yml
-[security-badge]: https://img.shields.io/github/actions/workflow/status/neoncitylights/sdmx/.github/workflows/main.yml?style=flat-square
-[security-url]: https://github.com/neoncitylights/sdmx/actions/workflows/security-audit.yml
-[codecov-badge]: https://img.shields.io/codecov/c/github/neoncitylights/rust?style=flat-square&logo=codecov&logoColor=%23fff
+[codecov]: https://img.shields.io/codecov/c/github/neoncitylights/rust?style=flat-square&logo=codecov&logoColor=%23fff
 [codecov-url]: https://codecov.io/gh/neoncitylights/sdmx
+[docs]: https://img.shields.io/docsrs/sdmx_json?style=flat-square&label=docs.rs
+[docs-url]: https://docs.rs/sdmx_json
 
 A Rust implementation of SDMX-JSON (Statistical Data and Metadata eXchange) using Serde.
 
 ## Install
-
-```shell
+```sh
 cargo add sdmx_json
 ```
 
 ## License
-
 Licensed under either of
-
 - Apache License, Version 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT license ([`LICENSE-MIT`](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 ### Contribution
-
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/crates/sdmx_json/README.md
+++ b/crates/sdmx_json/README.md
@@ -1,19 +1,16 @@
 # sdmx_json
 [![License][license]][license-url]
 [![CI][ci]][ci-url]
-[![Codecov][codecov]][codecov-url]
 [![Documentation][docs]][docs-url]
 
 [license]: https://img.shields.io/badge/License-MIT%20%26%20Apache%202.0-blue?style=flat-square
 [license-url]: #license
 [ci]: https://img.shields.io/github/deployments/neoncitylights/sdmx/github-pages?label=deploy&style=flat-square
 [ci-url]: https://github.com/neoncitylights/sdmx/actions/workflows/main.yml
-[codecov]: https://img.shields.io/codecov/c/github/neoncitylights/rust?style=flat-square&logo=codecov&logoColor=%23fff
-[codecov-url]: https://codecov.io/gh/neoncitylights/sdmx
 [docs]: https://img.shields.io/docsrs/sdmx_json?style=flat-square&label=docs.rs
 [docs-url]: https://docs.rs/sdmx_json
 
-A Rust implementation of SDMX-JSON (Statistical Data and Metadata eXchange) using Serde.
+A Rust implementation of [SDMX-JSON](https://github.com/sdmx-twg/sdmx-json) (Statistical Data and Metadata eXchange) using Serde.
 
 ## Install
 ```sh
@@ -22,6 +19,7 @@ cargo add sdmx_json
 
 ## License
 Licensed under either of
+
 - Apache License, Version 2.0 ([`LICENSE-APACHE`](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
 - MIT license ([`LICENSE-MIT`](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 


### PR DESCRIPTION
First unstable release. Followup improvements will continue (roadmap to v1 is written in #18)