### PR TITLE
docs: document modules and symbols

### DIFF
--- a/crates/sdmx_json/CHANGELOG.md
+++ b/crates/sdmx_json/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v0.2.0 (Unreleased)
+
+### Breaking changes
+- metadata: The type `Attributes` is now correctly named `Attribute`.
+- primitives: The types `crate::metadata::StatusMessage` and `crate::primitives::Error` were consolidated into one type, `crate::primitives::StatusMessage`.
+- structure: The `CascadeValues` variant `String` was replaced with a `Boolean` variant.
+
+### Bugfixes
+- data: In `DataSet`, the fields `dimension_group_attributes`, `series`, and `observations` were fixed to have a less generic type.
+- data: In `Series`, the field type `annotations` was corrected to be a collection of indices that reference annotations (from `Option<Vec<Annotation>>` to `Option<Vec<usize>>`).
+- data: In `Series`, the field type `observations` was corrected to be less generic, from `Option<SdmxObject>` to `Option<HashMap<String, Vec<SdmxValue>>>`.
+- primitives: In `StatusMessage`, the `code` field is changed from `f64` to `u16` (smallest size possible for representing HTTP status codes). It assumes this is an error in the original specification / JSON schema, which specified `number` (which can be an integer or floating point), instead of `integer`. **Note** that this also patches the original sample files, which are presumed to have been caused by having been partially or fully generated from the original JSON schema.
+- primitives: In `MetaManyReceivers`, the fields `name` and `links` will no longer serialize if it is a `None` variant.
+- primitives: In `MetaSingleReceiver`, the field `name` will no longer serialize if it is a `None` variant.
+
+### Documentation
+- All modules and symbols now have top-level documentation.
+
 ## v0.1.0 (2024-12-15)
 
 - Initial release of the sdmx_json library

--- a/crates/sdmx_json/CHANGELOG.md
+++ b/crates/sdmx_json/CHANGELOG.md
@@ -16,7 +16,7 @@
 - primitives: In `MetaSingleReceiver`, the field `name` will no longer serialize if it is a `None` variant.
 
 ### Documentation
-- All modules and symbols now have top-level documentation.
+- All modules and symbols now have top-level documentation. Some symbols have a somewhat basic description, and will be improved upon in the future.
 
 ## v0.1.0 (2024-12-15)
 

--- a/crates/sdmx_json/src/data.rs
+++ b/crates/sdmx_json/src/data.rs
@@ -1,12 +1,14 @@
 use crate::primitives::{
-	Action, Annotation, DataType, Error, Link, LocalizedText, MetaSingleReceiver, NumberOrString,
-	SdmxObject, SdmxValue,
+	Action, Annotation, DataType, Link, LocalizedText, MetaSingleReceiver, NumberOrString,
+	SdmxValue, StatusMessage,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// The top-level type of a JSON file that conforms to the
+/// SDMX-JSON Data Message format.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct DataMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -14,7 +16,7 @@ pub struct DataMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub data: Option<Data>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub error: Option<Error>,
+	pub error: Option<StatusMessage>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
@@ -41,6 +43,7 @@ impl TryFrom<Value> for DataMessage {
 	}
 }
 
+/// The associated data with a data message.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Data {
@@ -53,6 +56,8 @@ pub struct Data {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The structural metadata for interpreting the data contained
+/// in the message.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Structure {
@@ -71,10 +76,15 @@ pub struct Structure {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A short, convenient type alias to [`DimsMeasuresAttributes`].
 pub type Dimensions = DimsMeasuresAttributes;
+/// A short, convenient type alias to [`DimsMeasuresAttributes`].
 pub type Measures = DimsMeasuresAttributes;
+/// A short, convenient type alias to [`DimsMeasuresAttributes`].
 pub type Attributes = DimsMeasuresAttributes;
 
+/// An object which either represents multiple dimensions,
+/// multiple measures, or multiple attributes.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DimsMeasuresAttributes {
@@ -91,6 +101,7 @@ pub struct DimsMeasuresAttributes {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A dimension, measure, or attribute used in the message.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Component {
@@ -123,6 +134,8 @@ pub struct Component {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The relationship between an attribute and other data structure
+/// definition components as defined in the data structure definition.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AttributeRelationship {
@@ -141,6 +154,7 @@ pub struct AttributeRelationship {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The representation for a component.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Format {
@@ -177,6 +191,7 @@ pub struct Format {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A particular value for a component in a message.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct ComponentValue {
 	pub id: String,
@@ -206,6 +221,9 @@ pub struct ComponentValue {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A collection of observations with meta-information
+/// about the dataset (when it was published, reported,
+/// how long the dataset is valid, etc).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DataSet {
@@ -232,24 +250,25 @@ pub struct DataSet {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attributes: Option<Vec<SdmxValue>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub dimension_group_attributes: Option<SdmxObject>,
+	pub dimension_group_attributes: Option<HashMap<String, Vec<SdmxValue>>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub series: Option<Series>,
+	pub series: Option<HashMap<String, Series>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub observations: Option<SdmxObject>,
+	pub observations: Option<HashMap<String, Vec<SdmxValue>>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A set of data points.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Series {
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub annotations: Option<Vec<Annotation>>,
+	pub annotations: Option<Vec<usize>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub attributes: Option<Vec<SdmxValue>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub observations: Option<SdmxObject>,
+	pub observations: Option<HashMap<String, Vec<SdmxValue>>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,

--- a/crates/sdmx_json/src/lib.rs
+++ b/crates/sdmx_json/src/lib.rs
@@ -2,15 +2,57 @@
 
 //! A Rust implementation of SDMX-JSON (Statistical Data and Metadata eXchange)
 //! using Serde.
+//!
+//! All JSON files are implemented with a top-level type, e.g
+//! [`DataMesssage`][crate::data::DataMessage],
+//! [`MetadataMessage`][crate::metadata::MetadataMessage],
+//! and [`StructureMessage`][crate::structure::StructureMessage].
 
 #[macro_use]
 mod macros;
 
-/// SDMX-JSON data message format
+/// SDMX-JSON Data Message format, 2.0.0 (aligned with SDMX 3.0.0)
+///
+/// This module implements [SDMX-JSON Data Message 2.0.0][data].
+/// The Data Message format allows for exchanging contextual statistics
+/// data via the JSON file format.
+///
+/// JSON files in this format are implemented in the top-level root type,
+/// [`DataMessage`][crate::data::DataMessage].
+/// They can be deserialized from a [`String`], a [`&[u8]`][slice],
+/// and a [`Value`][serde_json::Value].
+///
+/// [data]: <https://github.com/sdmx-twg/sdmx-json/tree/master/data-message>
 pub mod data;
-/// SDMX-JSON metadata message format
+
+/// SDMX-JSON Metadata Message format, 2.0.0 (aligned with SDMX 3.0.0)
+///
+/// This module implements [SDMX-JSON Metadata Message 2.0.0][metadata].
+/// The Metadata Message format includes information that describes
+/// the statistical data itself.
+///
+/// JSON files in this format are implemented in the top-level root type,
+/// [`MetadataMessage`][crate::metadata::MetadataMessage].
+/// They can be deserialized from a [`String`], a [`&[u8]`][slice],
+/// and a [`Value`][serde_json::Value].
+///
+/// [metadata]: <https://github.com/sdmx-twg/sdmx-json/tree/master/metadata-message>
 pub mod metadata;
+
 /// Common foundational types shared between the message formats
 pub mod primitives;
-/// SDMX-JSON structure message format
+
+/// SDMX-JSON Structure Message format, 2.0.0 (aligned with SDMX 3.0.0)
+///
+/// This module implements [SDMX-JSON Structure Message 2.0.0][structure].
+/// The Structure Message format is used for describing objects in
+/// RESTful API services to make data more easily discoverable
+/// and consumable.
+///
+/// JSON files in this format are implemented in the top-level root type,
+/// [`StructureMessage`][crate::structure::StructureMessage].
+/// They can be deserialized from a [`String`], a [`&[u8]`][slice],
+/// and a [`Value`][serde_json::Value].
+///
+/// [structure]: https://github.com/sdmx-twg/sdmx-json/tree/master/structure-message
 pub mod structure;

--- a/crates/sdmx_json/src/metadata.rs
+++ b/crates/sdmx_json/src/metadata.rs
@@ -1,11 +1,14 @@
 use crate::primitives::{
-	Action, Annotation, DataType, Link, LocalizedText, MetaManyReceivers, NumberOrString, SdmxValue,
+	Action, Annotation, DataType, Link, LocalizedText, MetaManyReceivers, NumberOrString,
+	SdmxValue, StatusMessage,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// The top-level type of a JSON file that conforms to the
+/// SDMX-JSON Metadata Message format.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct MetadataMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -40,6 +43,7 @@ impl TryFrom<Value> for MetadataMessage {
 	}
 }
 
+/// The associated data with a metadata message.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Data {
@@ -50,6 +54,9 @@ pub struct Data {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A collection of reported metadata against a set of values
+/// for a given full or partial target identifier,
+/// as described in a metadata structure definition.
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataSet {
@@ -88,26 +95,29 @@ pub struct MetadataSet {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub descriptions: Option<LocalizedText>,
 	pub targets: Vec<String>,
-	pub attributes: Vec<Attributes>,
+	pub attributes: Vec<Attribute>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A reported metadata attribute value.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-pub struct Attributes {
+pub struct Attribute {
 	pub id: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub annotations: Option<Vec<Annotation>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub format: Option<Format>,
 	pub value: Option<SdmxValue>,
-	pub attributes: Option<Vec<Attributes>>,
+	pub attributes: Option<Vec<Attribute>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The representation for a component which describes
+/// the possible content for component values.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Format {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -139,29 +149,4 @@ pub struct Format {
 	pub other: Option<HashMap<String, Value>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
-pub struct StatusMessage {
-	pub code: f64, // NOTE: Original schema specifies this as number instead of integer(?)
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub title: Option<String>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub titles: Option<LocalizedText>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub detail: Option<String>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub details: Option<LocalizedText>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub links: Option<Vec<Link>>,
-	#[serde(skip_serializing_if = "Option::is_none")]
-	#[serde(flatten)]
-	pub other: Option<HashMap<String, Value>>,
-}
-
-impl_extendable!(
-	MetadataMessage,
-	Data,
-	MetadataSet,
-	Attributes,
-	Format,
-	StatusMessage,
-);
+impl_extendable!(MetadataMessage, Data, MetadataSet, Attribute, Format);

--- a/crates/sdmx_json/src/primitives.rs
+++ b/crates/sdmx_json/src/primitives.rs
@@ -309,6 +309,7 @@ pub struct MetaManyReceivers {
 	pub sender: Sender,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub receivers: Option<Vec<Receiver>>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]

--- a/crates/sdmx_json/src/primitives.rs
+++ b/crates/sdmx_json/src/primitives.rs
@@ -343,7 +343,8 @@ pub enum SdmxValue {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SdmxObject(pub HashMap<String, SdmxValue>);
 
-/// A reserved value within an associated data domain.
+/// A reserved value within an associated data domain and
+/// some semantic meaning.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SentinelValue {

--- a/crates/sdmx_json/src/primitives.rs
+++ b/crates/sdmx_json/src/primitives.rs
@@ -3,12 +3,18 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// A marker trait for denoting that an object is extendable,
+/// where it can accept additional properties beyond those
+/// defined in the SDMX-JSON schema.
 pub trait Extendable {
 	fn other(&self) -> Option<&HashMap<String, Value>>;
 }
 
+/// A map between languages and the associated content
+/// in that language.
 pub type LocalizedText = HashMap<String, String>;
 
+/// A link to an external resource.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Link {
 	#[serde(flatten)]
@@ -32,10 +38,15 @@ pub struct Link {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A reference to a digital location, which may either
+/// be a hyperlink reference (href),
+/// or a uniform resource name (URN)
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Location {
+	/// A hyperlink reference
 	Href(String),
+	/// A uniform resource name
 	Urn(String),
 }
 
@@ -47,6 +58,8 @@ impl Location {
 	}
 }
 
+/// An action which describes how or why the data is being transmitted
+/// from the sender's side.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Action {
 	Append,
@@ -56,6 +69,7 @@ pub enum Action {
 	Information,
 }
 
+/// Extra information that may be attached to another object.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub struct Annotation {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -78,6 +92,7 @@ pub struct Annotation {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A collection of contact information for an individual.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Contact {
@@ -108,6 +123,7 @@ pub struct Contact {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The specific data format for representing something.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum DataType {
 	String,
@@ -205,19 +221,26 @@ impl From<TimeDimensionDataType> for DataType {
 	}
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-pub struct Error {
-	pub code: f64, // NOTE: Original schema specifies this as number instead of integer(?)
-	pub title: String,
-	pub titles: LocalizedText,
-	pub detail: String,
-	pub details: LocalizedText,
-	pub links: Vec<Link>,
+/// A message with an HTTP status code, presumably an error status code.
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+pub struct StatusMessage {
+	pub code: usize,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub title: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub titles: Option<LocalizedText>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub detail: Option<String>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub details: Option<LocalizedText>,
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub links: Option<Vec<Link>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// An individual responsible for transmitting/receiving a message.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Party {
@@ -233,9 +256,14 @@ pub struct Party {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The party responsible for transmitting a message.
 pub type Sender = Party;
+/// The party responsible for receiving a message.
 pub type Receiver = Party;
 
+/// Non-standard information and basic technical information
+/// associated with a message, which may have a single receiver
+/// (but no more than one).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaSingleReceiver {
@@ -247,6 +275,7 @@ pub struct MetaSingleReceiver {
 	pub prepared: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub content_languages: Option<Vec<String>>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub names: Option<LocalizedText>,
@@ -259,6 +288,9 @@ pub struct MetaSingleReceiver {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Non-standard information and basic technical information
+/// associated with a message, which may have multiple
+/// receivers.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetaManyReceivers {
@@ -270,6 +302,7 @@ pub struct MetaManyReceivers {
 	pub prepared: String,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub content_languages: Option<Vec<String>>,
+	#[serde(skip_serializing_if = "Option::is_none")]
 	pub name: Option<String>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub names: Option<LocalizedText>,
@@ -282,12 +315,17 @@ pub struct MetaManyReceivers {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A primitive for representing either a string or signed integer.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum NumberOrString {
 	Number(isize),
 	String(String),
 }
 
+/// A primitive for describing pure SDMX-JSON values.
+///
+/// This type may or may not be replaced with
+/// [`serde_json::Value`] in the future.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum SdmxValue {
@@ -300,9 +338,11 @@ pub enum SdmxValue {
 	Array(Box<Vec<SdmxValue>>),
 }
 
+/// An object of keys mapping to pure SDMX-JSON primitive values.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SdmxObject(pub HashMap<String, SdmxValue>);
 
+/// A reserved value within an associated data domain.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SentinelValue {
@@ -325,7 +365,7 @@ impl_extendable!(
 	Link,
 	Annotation,
 	Contact,
-	Error,
+	StatusMessage,
 	Party,
 	MetaSingleReceiver,
 	MetaManyReceivers,

--- a/crates/sdmx_json/src/structure/all.rs
+++ b/crates/sdmx_json/src/structure/all.rs
@@ -1,5 +1,5 @@
 use crate::primitives::{
-	Annotation, DataType, Error, Link, LocalizedText, MetaSingleReceiver, SentinelValue,
+	Annotation, DataType, Link, LocalizedText, MetaSingleReceiver, SentinelValue, StatusMessage,
 };
 use crate::structure::{CommonArtefactType, DataConstraint, MetadataConstraint};
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,7 @@ pub struct StructureMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub data: Option<Data>,
 	#[serde(skip_serializing_if = "Option::is_none")]
-	pub errors: Option<Vec<Error>>,
+	pub errors: Option<Vec<StatusMessage>>,
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[serde(flatten)]
 	pub other: Option<HashMap<String, Value>>,

--- a/crates/sdmx_json/src/structure/all.rs
+++ b/crates/sdmx_json/src/structure/all.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+/// The top-level type of a JSON file that conforms to the
+/// SDMX-JSON Structure Message format.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct StructureMessage {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -41,6 +43,7 @@ impl TryFrom<Value> for StructureMessage {
 	}
 }
 
+/// The associated data with a structure message.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Data {
 	#[serde(skip_serializing_if = "Option::is_none")]
@@ -120,6 +123,13 @@ pub struct Data {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A primitive in the SDMX Informational Model which
+/// describes a concept.
+///
+/// **Note**: Since there are many variants which contain
+/// a somewhat large memory layout (and some much larger
+/// than others), every variant is boxed to ensure a smaller
+/// memory footprint for the entire enum.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum ArtefactType {
 	DataStructures(Box<DataStructure>),
@@ -160,6 +170,7 @@ pub enum ArtefactType {
 	UserDefinedOperatorSchemes(Box<UserDefinedOperatorsScheme>),
 }
 
+/// An abstract generic item within an item scheme.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Item {
 	pub id: String,
@@ -180,6 +191,8 @@ pub struct Item {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A collection of metadata concepts, their structure
+/// and usage when used to collect or disseminate data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataStructure {
@@ -194,6 +207,8 @@ pub struct DataStructure {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A structure of the grouping to the sets of structural concepts
+/// that have a defined structural role in the data structure definition.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataStructureComponents {
@@ -209,6 +224,7 @@ pub struct DataStructureComponents {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A list of attributes in the data structure definition.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AttributeList {
@@ -226,6 +242,7 @@ pub struct AttributeList {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A characteristic of an object or entity.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Attribute {
@@ -246,6 +263,7 @@ pub struct Attribute {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Indicates whether something is required or optional.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Usage {
@@ -253,6 +271,8 @@ pub enum Usage {
 	Optional,
 }
 
+/// The association between an attribute and other
+/// data structure definition components.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AttributeRelationship {
@@ -271,6 +291,7 @@ pub struct AttributeRelationship {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The data representation of an attribute.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalRepresentation {
@@ -289,12 +310,17 @@ pub struct LocalRepresentation {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The max occurrences of something, which can either
+/// be an unsigned integer or unbounded (can occur without
+/// any upper limit).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum MaxOccurs {
 	Signed(usize),
 	Unbounded,
 }
 
+/// A restricted version of [`Format`] that only allows facets
+/// and text types applicable to codes.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct EnumerationFormat {
@@ -329,6 +355,9 @@ pub struct EnumerationFormat {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The information for describing a range of data formats
+/// restricted to the representations allowed for all components
+/// except for target objects.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Format {
@@ -364,6 +393,8 @@ pub struct Format {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Defines how a metadata attribute is used within
+/// a data structure.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataAttributeUsage {
@@ -378,6 +409,8 @@ pub struct MetadataAttributeUsage {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Defines the order in which child dimensions will
+/// appear in data formats.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DimensionList {
@@ -396,6 +429,8 @@ pub struct DimensionList {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A dimension which represents a statistical series,
+/// such as a time series.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Dimension {
@@ -416,6 +451,7 @@ pub struct Dimension {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A statistical series representing time.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeDimension {
@@ -432,6 +468,8 @@ pub struct TimeDimension {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A representation of a time dimension, which may contain
+/// sentinel values.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeDimensionFormat {
@@ -446,6 +484,7 @@ pub struct TimeDimensionFormat {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The specific data type of a time dimension.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TimeDimensionDataType {
 	ObservationalTimePeriod,
@@ -519,6 +558,8 @@ impl TryFrom<DataType> for TimeDimensionDataType {
 	}
 }
 
+/// Specifies attribute values which have the same value
+/// based on some common dimensionality.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Group {
@@ -534,6 +575,8 @@ pub struct Group {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Describes the structure of the measure descriptor
+/// for a data structure definition.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct MeasureList {
 	pub id: String,
@@ -548,6 +591,8 @@ pub struct MeasureList {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A concept that quantifies the size, amount
+/// or degree of something.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Measure {
@@ -566,6 +611,8 @@ pub struct Measure {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A collection of metadata concepts and their structure
+/// when used to collect or disseminate reference metadata.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataStructure {
@@ -578,6 +625,7 @@ pub struct MetadataStructure {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A set of components that makeup the metadata structure.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataStructureComponents {
@@ -588,6 +636,8 @@ pub struct MetadataStructureComponents {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A set of metadata attributes that can be defined
+/// as a hierarchy.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataAttributeList {
@@ -603,6 +653,7 @@ pub struct MetadataAttributeList {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A metadata characteristic of an object or entity.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataAttribute {
@@ -626,6 +677,7 @@ pub struct MetadataAttribute {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a category.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CategoryScheme {
@@ -640,6 +692,7 @@ pub struct CategoryScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a concept.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConceptScheme {
@@ -660,6 +713,7 @@ pub struct ConceptScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A core representation for a concept.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CoreRepresentation {
@@ -678,6 +732,7 @@ pub struct CoreRepresentation {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A reference to an ISO 11179 concept.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct IsoConceptReference {
@@ -689,6 +744,7 @@ pub struct IsoConceptReference {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a codelist.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Codelist {
@@ -705,6 +761,7 @@ pub struct Codelist {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a geography codelist.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct GeographyCodelist {
@@ -719,6 +776,7 @@ pub struct GeographyCodelist {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a geographic grid codelist.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct GeoGridCodelist {
@@ -733,6 +791,7 @@ pub struct GeoGridCodelist {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for an agency.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AgencyScheme {
@@ -747,6 +806,7 @@ pub struct AgencyScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a data provider.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataProviderScheme {
@@ -761,6 +821,7 @@ pub struct DataProviderScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a data consumer.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataConsumerScheme {
@@ -775,6 +836,7 @@ pub struct DataConsumerScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a metadata provider.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataProviderScheme {
@@ -789,6 +851,7 @@ pub struct MetadataProviderScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for an organization unit.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct OrganizationUnitScheme {
@@ -803,6 +866,8 @@ pub struct OrganizationUnitScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The structure of data that will be provided for
+/// different reference periods.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Dataflow {
@@ -815,6 +880,7 @@ pub struct Dataflow {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for name personalization.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct NamePersonalizationScheme {
@@ -829,6 +895,7 @@ pub struct NamePersonalizationScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a reporting taxonomy.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ReportingTaxonomy {
@@ -843,6 +910,7 @@ pub struct ReportingTaxonomy {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Describes what something (the source) falls under (the target).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Categorization {
@@ -857,6 +925,7 @@ pub struct Categorization {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a custom type.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomTypeScheme {
@@ -871,6 +940,8 @@ pub struct CustomTypeScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a VTL (Validation and Transformation Language)
+/// mapping.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct VtlMappingScheme {
@@ -885,6 +956,7 @@ pub struct VtlMappingScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a ruleset.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct RulesetScheme {
@@ -899,6 +971,7 @@ pub struct RulesetScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a transformation.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TransformationScheme {
@@ -913,6 +986,7 @@ pub struct TransformationScheme {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The item scheme for a user defined operator.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct UserDefinedOperatorsScheme {

--- a/crates/sdmx_json/src/structure/common.rs
+++ b/crates/sdmx_json/src/structure/common.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// Properties that all SDMX artefacts share.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CommonArtefactType {

--- a/crates/sdmx_json/src/structure/constraints.rs
+++ b/crates/sdmx_json/src/structure/constraints.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 
+/// A subset of the definition of the allowable (or available)
+/// content of a dataset.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataConstraint {
@@ -23,6 +25,8 @@ pub struct DataConstraint {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A subset of the definition of the allowable (or available)
+/// content of a metadata set.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataConstraint {
@@ -40,12 +44,16 @@ pub struct MetadataConstraint {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The purpose of a constraint, which informs the constraint
+/// if the data is actually present, or if it defines what
+/// data is allowed.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Role {
 	Actual,
 	Allowed,
 }
 
+/// A collection of references to data-constrainable artefacts.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ConstraintAttachment {
@@ -66,6 +74,7 @@ pub struct ConstraintAttachment {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A collection of references to metadata-constrainable artefacts.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataConstraintAttachment {
@@ -88,6 +97,8 @@ pub struct MetadataConstraintAttachment {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A data source which accepts a standard SDMX query message
+/// and responds appropriately.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryableDataSource {
@@ -104,6 +115,7 @@ pub struct QueryableDataSource {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A subset of data within multi-dimensional data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CubeRegion {
@@ -122,6 +134,8 @@ pub struct CubeRegion {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The structure for providing values for data attributes,
+/// measures, or metadata attributes.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ComponentValueSet {
@@ -139,6 +153,7 @@ pub struct ComponentValueSet {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A string or simple component value.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum StringOrScv {
@@ -146,6 +161,7 @@ pub enum StringOrScv {
 	SimpleComponent(SimpleComponentValue),
 }
 
+/// A time period value expressed as a range.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TimeRangeValue {
@@ -162,6 +178,8 @@ pub struct TimeRangeValue {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A time period that describes whether a period
+/// is inclusive in a range.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct TimePeriodRange {
@@ -174,6 +192,7 @@ pub struct TimePeriodRange {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A simple value for a component.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SimpleComponentValue {
@@ -190,13 +209,16 @@ pub struct SimpleComponentValue {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Indicates whether a value should be cascaded.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum CascadeValues {
-	String(String),
+	Boolean(bool),
 	#[serde(rename = "excluderoot")]
 	ExcludeRoot,
 }
 
+/// A set of values for a dimension that defines
+/// a data cube region.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct CubeRegionKey {
@@ -218,6 +240,7 @@ pub struct CubeRegionKey {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A collection of full or partial data keys (dimension values).
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataKeySet {
@@ -228,6 +251,7 @@ pub struct DataKeySet {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A region which defines a distinct full or partial data key.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataKey {
@@ -247,6 +271,7 @@ pub struct DataKey {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A dimension value for the purpose of defining a distinct data key.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataKeyValue {
@@ -261,6 +286,8 @@ pub struct DataKeyValue {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The structure for providing values for data attributes,
+/// measures, or metadata attributes.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataComponentValueSet {
@@ -277,6 +304,7 @@ pub struct DataComponentValueSet {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// A string or data component value.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum StringOrDcv {
@@ -284,6 +312,7 @@ pub enum StringOrDcv {
 	Dcv(DataComponentValue),
 }
 
+/// A simple value for a component.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct DataComponentValue {
@@ -297,6 +326,8 @@ pub struct DataComponentValue {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Describes the report structure and the metadata target
+/// from that structure on which the region is based.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataTargetRegion {
@@ -317,6 +348,7 @@ pub struct MetadataTargetRegion {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// Describes the vaues provided for a metadata attribute.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataAttributeValueSet {
@@ -334,6 +366,7 @@ pub struct MetadataAttributeValueSet {
 	pub other: Option<HashMap<String, Value>>,
 }
 
+/// The timing of releases of the constrained data.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct ReleaseCalendar {
 	pub offset: String,

--- a/crates/sdmx_json/src/structure/traits.rs
+++ b/crates/sdmx_json/src/structure/traits.rs
@@ -1,6 +1,7 @@
 use crate::primitives::{Annotation, Link, LocalizedText};
 use crate::structure::Item;
 
+/// A primitive type defined within the SDMX Informational Model specification.
 pub trait Artefact {
 	fn id(&self) -> &String;
 	fn agency_id(&self) -> Option<&String>;
@@ -14,6 +15,9 @@ pub trait Artefact {
 	fn links(&self) -> Option<&Vec<Link>>;
 }
 
+/// A primitive type which may or may not contain
+/// zero or more items, where said items may either
+/// be a subset or full collection.
 pub trait ItemScheme {
 	fn is_partial(&self) -> Option<bool>;
 	fn items(&self) -> Option<&Vec<Item>>;

--- a/crates/sdmx_json_de_tests/files/data_sample02.json
+++ b/crates/sdmx_json_de_tests/files/data_sample02.json
@@ -1,7 +1,7 @@
 {
 	"errors":[
 		{
-			"code":90483457.7170785,
+			"code":200,
 			"links":[
 				{
 					"href":"http://pUJaPHEeINvtthHXFshGsGCbxaW.szfPda3",
@@ -42,7 +42,7 @@
 			}
 		},
 		{
-			"code":-46883339.466014504,
+			"code":200,
 			"details":{
 				"vbbo-x-pis":"nostrud velit cillum"
 			},

--- a/crates/sdmx_json_de_tests/files/metadata_sample03.json
+++ b/crates/sdmx_json_de_tests/files/metadata_sample03.json
@@ -500,7 +500,7 @@
 	},
 	"errors":[
 		{
-			"code":96529995.76208287,
+			"code":200,
 			"title":"Title contains the title of the message, in best-match language value. A short, human-readable localised summary of the status that SHOULD NOT change from occurrence to occurrence of the status, except for purposes of localization.",
 			"details":{
 				"fr":"Detail contains the detailed text of the message, in parallel language values. A list of human-readable localised explanations specific to this occurrence of the status. Like title, this field’s value can be localized. It is fully customizable by the service providers and should provide enough detail to ease understanding the reasons of the status."
@@ -520,7 +520,7 @@
 			"detail":"Detail contains the detailed text of the message, in best-match language value. A human-readable localised explanation specific to this occurrence of the status. Like title, this field’s value can be localized. It is fully customizable by the service providers and should provide enough detail to ease understanding the reasons of the status."
 		},
 		{
-			"code":67157557.70123723,
+			"code":200,
 			"detail":"Detail contains the detailed text of the message, in best-match language value. A human-readable localised explanation specific to this occurrence of the status. Like title, this field’s value can be localized. It is fully customizable by the service providers and should provide enough detail to ease understanding the reasons of the status.",
 			"details":{
 				"en":"Detail contains the detailed text of the message, in parallel language values. A list of human-readable localised explanations specific to this occurrence of the status. Like title, this field’s value can be localized. It is fully customizable by the service providers and should provide enough detail to ease understanding the reasons of the status."
@@ -528,7 +528,7 @@
 			"title":"Title contains the title of the message, in best-match language value. A short, human-readable localised summary of the status that SHOULD NOT change from occurrence to occurrence of the status, except for purposes of localization."
 		},
 		{
-			"code":-13299148.194488943,
+			"code":200,
 			"title":"Title contains the title of the message, in best-match language value. A short, human-readable localised summary of the status that SHOULD NOT change from occurrence to occurrence of the status, except for purposes of localization.",
 			"links":[
 				{

--- a/crates/sdmx_json_de_tests/files/structure_sample02.json
+++ b/crates/sdmx_json_de_tests/files/structure_sample02.json
@@ -5491,7 +5491,7 @@
 	},
 	"errors":[
 		{
-			"code":1.1,
+			"code":200,
 			"title":"a",
 			"titles":{
 				"en-GB-oed":"a"

--- a/crates/sdmx_json_de_tests/src/lib.rs
+++ b/crates/sdmx_json_de_tests/src/lib.rs
@@ -47,48 +47,48 @@ mod tests {
 	#[cfg_attr(miri, ignore)]
 	fn test_data_sample01() {
 		let file = read_json::<DataMessage>(fixture!("data_sample01.json"));
-		assert!(file.is_ok());
+		assert!(file.is_ok(), "{:?}", file);
 	}
 
 	#[test]
 	#[cfg_attr(miri, ignore)]
 	fn test_data_sample02() {
 		let file = read_json::<DataMessage>(fixture!("data_sample02.json"));
-		assert!(file.is_ok());
+		assert!(file.is_ok(), "{:?}", file);
 	}
 
 	#[test]
 	#[cfg_attr(miri, ignore)]
 	fn test_metadata_sample01() {
 		let file = read_json::<MetadataMessage>(fixture!("metadata_sample01.json"));
-		assert!(file.is_ok());
+		assert!(file.is_ok(), "{:?}", file);
 	}
 
 	#[test]
 	#[cfg_attr(miri, ignore)]
 	fn test_metadata_sample02() {
 		let file = read_json::<MetadataMessage>(fixture!("metadata_sample02.json"));
-		assert!(file.is_ok());
+		assert!(file.is_ok(), "{:?}", file);
 	}
 
 	#[test]
 	#[cfg_attr(miri, ignore)]
 	fn test_metadata_sample03() {
 		let file = read_json::<MetadataMessage>(fixture!("metadata_sample03.json"));
-		assert!(file.is_ok());
+		assert!(file.is_ok(), "{:?}", file);
 	}
 
 	#[test]
 	#[cfg_attr(miri, ignore)]
 	fn test_structure_sample01() {
 		let file = read_json::<StructureMessage>(fixture!("structure_sample01.json"));
-		assert!(file.is_ok());
+		assert!(file.is_ok(), "{:?}", file);
 	}
 
 	#[test]
 	#[cfg_attr(miri, ignore)]
 	fn test_structure_sample02() {
 		let file = read_json::<StructureMessage>(fixture!("structure_sample02.json"));
-		assert!(file.is_ok());
+		assert!(file.is_ok(), "{:?}", file);
 	}
 }


### PR DESCRIPTION
## Summary
This also consolidates the Error and StatusMessage types into one type, StatusMessage.

Other changes:
- primitives: In StatusMessage, the `code` field is changed from `f64` to `u16` (smallest size possible for representing HTTP status codes). It assumes this is an error in the original specification / JSON schema, which specified `number` (which can be an integer or floating point), instead of `integer`. Note that this also patches the original sample files, which are presumed to have been partially or fully generated from the original JSON schema.
- primitives: In `MetaManyReceivers`, the fields `name` and `links` will no longer serialize if it is a None variant.
- primitives: In `MetaSingleReceiver`, the field `name` will no longer serialize if it is a None variant.
- data: In `DataSet`, the field types of `dimension_group_attributes`, `series`, and `observations` have been made more specific.
- data: In `Series`, the field type `annotations` was corrected to be a collection of indices that reference annotations. The `observations` field was also corrected to be more specific.
- metadata: The type `Attributes` was renamed to `Attribute`.

## Todo list
- [x] data module is documented
- [x] metadata module is documented
- [x] primitives module is documented
- [x] structures module is documented