### PR TITLE
ci: speed up audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate Cargo.lock if file does not exist
         if: env.cargo_lock_exists == 'false'
         run: cargo generate-lockfile
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
       - name: Run cargo-audit
-        uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo audit


### PR DESCRIPTION
Install binary of cargo-audit instead of manually compiling on every run (down from ~2mins to ~5-6 seconds)